### PR TITLE
Add playful layout for recommendations

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -369,3 +369,40 @@ a.back:hover {
   }
   
 }
+.recommendations section {
+  margin-bottom: 2rem;
+}
+
+.recommendations h2 {
+  font-size: 1.3rem;
+  background-color: #ffe680;
+  padding: 0.4rem 0.8rem;
+  border-radius: 0.5rem;
+  display: inline-block;
+}
+
+.recommendation-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.8rem;
+}
+
+.recommendation-list li {
+  background-color: #fff4e6;
+  border-radius: 0.5rem;
+  border: 2px dashed #ffd366;
+  padding: 0.8rem;
+}
+
+.recommendation-list li:nth-child(even) {
+  background-color: #e6f7ff;
+  border-color: #b3e5ff;
+}
+
+.recommendation-list a:hover {
+  text-decoration: underline;
+}
+

--- a/recommendations.html
+++ b/recommendations.html
@@ -1,41 +1,44 @@
 ---
 title: Terry Wang
 layout: default
+bodyClass: recommendations
 ---
 
-<div class="container">
+<div class="container recommendations">
     <div style="margin-top: 20px;">
         <a href="/" class="back">Back</a>
     </div>
     
     <h1 class="text-center">Recommendations</h1>
-    <h2>Articles <span class="weak">/ AI</span></h2>
-    <ul>
+    <section class="category">
+      <h2>Articles <span class="weak">/ AI</span> ✨</h2>
+      <ul class="recommendation-list">
         <li>
             <a href="https://www.anthropic.com/engineering/built-multi-agent-research-system">How we built our multi-agent research system</a> by Anthropic.
             <span class="weak">2025-06-13</span>
         </li>
         <li>
-            <a href="https://koomen.dev/essays/horseless-carriages/">AI Horseless Carriages</a> by Pete Koomen. 
+            <a href="https://koomen.dev/essays/horseless-carriages/">AI Horseless Carriages</a> by Pete Koomen.
             <span class="weak">2025-05-29</span>
         </li>
         <li>
-            <a href="https://lilianweng.github.io/posts/2025-05-01-thinking/">Why We Think</a> by Lilian Weng. 
+            <a href="https://lilianweng.github.io/posts/2025-05-01-thinking/">Why We Think</a> by Lilian Weng.
             <span class="weak">2025-05-01</span>
         </li>
         <li>
-            <a href="https://storage.googleapis.com/deepmind-media/Era-of-Experience%20/The%20Era%20of%20Experience%20Paper.pdf">The Era of Experience</a> by David Silver, Richard S. Sutton. 
+            <a href="https://storage.googleapis.com/deepmind-media/Era-of-Experience%20/The%20Era%20of%20Experience%20Paper.pdf">The Era of Experience</a> by David Silver, Richard S. Sutton.
             <span class="weak">2024-11-20</span>
         </li>
         <li>
             <a href="https://ysymyth.github.io/The-Second-Half/">The Second Half</a> by Shunyu Yao.
             <span class="weak">2025-04-10</span>
         </li>
-        
-    </ul>
+      </ul>
+    </section>
 
-    <h2>Articles <span class="weak">/ Design</span></h2>
-    <ul>
+    <section class="category">
+      <h2>Articles <span class="weak">/ Design</span> 🎨</h2>
+      <ul class="recommendation-list">
         <li>
             <a href="https://www.abccopywriting.com/2011/01/17/uncreative-and-proud">Uncreative and proud</a> by Tom Albrighton.
             <span class="weak">2011-01-17</span>
@@ -44,9 +47,11 @@ layout: default
             <a href="https://capwatkins.com/blog/the-boring-designer">The boring designer</a> by Cap Watkins.
             <span class="weak">2015-03-05</span>
         </li>
-    </ul>
-    <h2>Books</h2>
-    <ul>
+      </ul>
+    </section>
+    <section class="category">
+      <h2>Books 📚</h2>
+      <ul class="recommendation-list">
         <li><a href="http://book.douban.com/subject/1316642/">The Visual Display of Quantitative Information</a> by Edward Tufte</li>
         <li><a href="http://book.douban.com/subject/1742456/">Notes on the Synthesis of Form</a> by Christopher Alexander</li>
         <li><a href="http://book.douban.com/subject/1478928/">Designing Visual Interfaces</a> by Kevin Mullet and Darrell Sano</li>
@@ -56,10 +61,12 @@ layout: default
         <li><a href="http://abookapart.com/products/just-enough-research">Just Enough Research</a> by Erika Hall</li>
         <li><a href="http://shapeofdesignbook.com">The Shape of Design</a> by Frank Chimero</li>
         <li><a href="https://www.amazon.com/UX-Magic-Daniel-Rosenberg/dp/1708061614">UX Magic</a> by Daniel Rosenberg</li>
-    </ul>
+      </ul>
+    </section>
 
-    <h2>Talks</h2>
-    <ul>
+    <section class="category">
+      <h2>Talks 🎤</h2>
+      <ul class="recommendation-list">
         <li>
             <a href="http://vimeo.com/36579366">Invent on principles</a> by Bret Victor
         </li>
@@ -72,7 +79,7 @@ layout: default
         <li>
             <a href="https://www.ted.com/talks/milton_glaser_using_design_to_make_ideas_new">Using design to make ideas new</a> by Milton Glaser
         </li>
-    </ul>
+      </ul>
+    </section>
 
-    
 </div>


### PR DESCRIPTION
## Summary
- redesign `recommendations.html` with colorful card sections
- style new `.recommendations` layout in CSS

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68513a02f2b083239e3ad65efb5ccf54