### PR TITLE
Add The Bitter Lesson article to AI recommendations

### DIFF
--- a/recommendations.html
+++ b/recommendations.html
@@ -60,6 +60,10 @@ bodyClass: recommendations
           <a href="https://www.darioamodei.com/essay/machines-of-loving-grace">Machines of Loving Grace</a> by Dario Amodei.
           <span class="weak">2024-05-05</span>
         </li>
+        <li>
+          <a href="http://www.incompleteideas.net/IncIdeas/BitterLesson.html">The Bitter Lesson</a> by Rich Sutton.
+          <span class="weak">2019-03-13</span>
+        </li>
       </ul>
     </section>
 


### PR DESCRIPTION
## Summary
- add "The Bitter Lesson" by Rich Sutton to the AI recommendations list with its publication date

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d99bc0ac8323af4eab93ed896947